### PR TITLE
u-boot: fix board id detection fallback

### DIFF
--- a/runme.sh
+++ b/runme.sh
@@ -7,7 +7,7 @@ declare -A GIT_REL GIT_COMMIT GIT_URL
 GIT_REL[imx-atf]=lf-6.6.36-2.1.0
 GIT_URL[imx-atf]=https://github.com/nxp-imx/imx-atf.git
 GIT_REL[uboot-imx]=lf-6.6.52-2.2.0-sr-imx8
-GIT_COMMIT[uboot-imx]=7ee00406e63caa4d9176e8a337621fd9b82f68a5
+GIT_COMMIT[uboot-imx]=01e1031959b96349f3f887a6f6818d4ca60c8dc7
 GIT_URL[uboot-imx]=https://github.com/SolidRun/u-boot.git
 GIT_REL[linux-imx]=lf-6.6-sr-imx8
 GIT_COMMIT[linux-imx]=6d49c56dca1fe4329d2b303bc9b4f729004cede1


### PR DESCRIPTION
A bug in the strlen call caused wrong fallback logic and compile warnings/errors